### PR TITLE
Add department templates and selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore build outputs
+input-app/dist/
+restore-app/dist/
+input-app/node_modules/.tmp/
+restore-app/node_modules/.tmp/

--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -2,68 +2,65 @@ import React, { useState, useEffect, useRef } from 'react';
 import QRCode from 'qrcode';
 import pako from 'pako';
 import CryptoJS from 'crypto-js';
-import * as Encoding from 'encoding-japanese'; // encoding-japaneseライブラリ全体をインポート
+import * as Encoding from 'encoding-japanese';
+import { templates, departmentMap } from './templates';
+import type { Field } from './templates';
 
 const App: React.FC = () => {
-  const [formData, setFormData] = useState({
-    name: 'サトウタロウ',
-    birthYear: '1979',
-    birthMonth: '03',
-    birthDay: '25',
-    age: '30',
-    gender: '1',
-    symptoms: ['3', '4', '6'],
-    duration: '2',
-    history: ['8', '1', '2'],
-    freeText: '今すぐ受診させてほしい',
-  });
-
+  const [departmentId, setDepartmentId] = useState('');
+  const [formData, setFormData] = useState<Record<string, string | string[]>>({});
   const [qrData, setQrData] = useState('');
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
 
-  const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY; // 環境変数から読み込み
+  const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY;
 
   useEffect(() => {
-    const generateQrData = () => {
-      const csvData = [
-        formData.name,
-        formData.birthYear,
-        formData.birthMonth,
-        formData.birthDay,
-        formData.age,
-        formData.gender,
-        formData.symptoms.join(';'),
-        formData.duration,
-        formData.history.join(';'),
-        formData.freeText,
-      ].join(',');
+    if (!departmentId) {
+      setQrData('');
+      return;
+    }
+    const template = templates[departmentId];
+    if (!template) return;
+    const csvData = [
+      departmentId,
+      ...template.fields.map((field: Field) => {
+        const val = formData[field.name];
+        if (field.type === 'checkbox') {
+          return Array.isArray(val) ? val.join(';') : '';
+        }
+        return val ?? '';
+      }),
+    ].join(',');
 
-      // 1. Convert to Shift_JIS
-      const sjis_array = Encoding.convert(csvData, { to: 'SJIS', type: 'arraybuffer' });
+    const sjis_array = Encoding.convert(csvData, { to: 'SJIS', type: 'arraybuffer' });
+    const compressed = pako.deflate(sjis_array);
+    const encrypted = CryptoJS.AES.encrypt(
+      CryptoJS.lib.WordArray.create(compressed),
+      encryptionKey
+    ).toString();
 
-      // 2. zlib compression
-      const compressed = pako.deflate(sjis_array);
-
-      // 3. AES encryption
-      const encrypted = CryptoJS.AES.encrypt(
-        CryptoJS.lib.WordArray.create(compressed),
-        encryptionKey
-      ).toString();
-
-      // 4. Base64 encode (already done by CryptoJS)
-      setQrData(encrypted);
-    };
-
-    generateQrData();
-  }, [formData]);
+    setQrData(encrypted);
+  }, [formData, departmentId]);
 
   useEffect(() => {
     if (qrCanvasRef.current && qrData) {
-      QRCode.toCanvas(qrCanvasRef.current, qrData, { errorCorrectionLevel: 'M', width: 256 }, function (error: any) {
+      QRCode.toCanvas(qrCanvasRef.current, qrData, { errorCorrectionLevel: 'M', width: 256 }, function (error: unknown) {
         if (error) console.error(error);
       });
     }
   }, [qrData]);
+
+  useEffect(() => {
+    if (departmentId) {
+      const initial: Record<string, string | string[]> = {};
+      templates[departmentId].fields.forEach((f) => {
+        initial[f.name] = f.type === 'checkbox' ? [] : '';
+      });
+      setFormData(initial);
+    } else {
+      setFormData({});
+    }
+  }, [departmentId]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
     const { name, value } = e.target;
@@ -72,168 +69,113 @@ const App: React.FC = () => {
 
   const handleCheckboxChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value, checked } = e.target;
-    const currentValues = formData[name as keyof typeof formData] as string[];
+    const current = formData[name] as string[];
     if (checked) {
-      setFormData({ ...formData, [name]: [...currentValues, value] });
+      setFormData({ ...formData, [name]: [...current, value] });
     } else {
-      setFormData({ ...formData, [name]: currentValues.filter((v) => v !== value) });
+      setFormData({ ...formData, [name]: current.filter((v) => v !== value) });
     }
   };
+
+  const renderField = (field: Field) => {
+    switch (field.type) {
+      case 'text':
+      case 'number':
+        return (
+          <div className="mb-3" key={field.name}>
+            <label className="form-label">{field.label}</label>
+            <input
+              type={field.type === 'number' ? 'number' : 'text'}
+              className="form-control"
+              name={field.name}
+              value={formData[field.name] || ''}
+              onChange={handleInputChange}
+              maxLength={field.name === 'freeText' ? 300 : undefined}
+            />
+          </div>
+        );
+      case 'select':
+        return (
+          <div className="mb-3" key={field.name}>
+            <label className="form-label">{field.label}</label>
+            <select
+              className="form-select"
+              name={field.name}
+              value={formData[field.name] || ''}
+              onChange={handleInputChange}
+            >
+              {field.options?.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        );
+      case 'checkbox':
+        return (
+          <div className="mb-3" key={field.name}>
+            <label className="form-label">{field.label}</label>
+            <div>
+              {field.options?.map((opt) => (
+                <div className="form-check form-check-inline" key={opt.value}>
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    name={field.name}
+                    value={opt.value}
+                    onChange={handleCheckboxChange}
+                    checked={(formData[field.name] || []).includes(opt.value)}
+                  />
+                  <label className="form-check-label">{opt.label}</label>
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const currentTemplate = departmentId ? templates[departmentId] : undefined;
 
   return (
     <div className="container mt-5">
       <h1>QR問診票入力</h1>
-      <form>
-        <div className="mb-3">
-          <label className="form-label">氏名</label>
-          <input
-            type="text"
-            className="form-control"
-            name="name"
-            value={formData.name}
-            onChange={handleInputChange}
-          />
-        </div>
-        <div className="row mb-3">
-          <div className="col">
-            <label className="form-label">生年月日（年）</label>
-            <input
-              type="number"
-              className="form-control"
-              name="birthYear"
-              value={formData.birthYear}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="col">
-            <label className="form-label">月</label>
-            <input
-              type="number"
-              className="form-control"
-              name="birthMonth"
-              value={formData.birthMonth}
-              onChange={handleInputChange}
-            />
-          </div>
-          <div className="col">
-            <label className="form-label">日</label>
-            <input
-              type="number"
-              className="form-control"
-              name="birthDay"
-              value={formData.birthDay}
-              onChange={handleInputChange}
-            />
-          </div>
-        </div>
-        <div className="mb-3">
-          <label className="form-label">年齢</label>
-          <input
-            type="number"
-            className="form-control"
-            name="age"
-            value={formData.age}
-            onChange={handleInputChange}
-          />
-        </div>
-        <div className="mb-3">
-          <label className="form-label">性別</label>
-          <select
-            className="form-select"
-            name="gender"
-            value={formData.gender}
-            onChange={handleInputChange}
-          >
-            <option value="1">男性</option>
-            <option value="2">女性</option>
-            <option value="3">その他</option>
-          </select>
-        </div>
-        <div className="mb-3">
-          <label className="form-label">症状</label>
-          <div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="symptoms" value="3" onChange={handleCheckboxChange} checked={formData.symptoms.includes('3')} />
-              <label className="form-check-label">頭痛</label>
-            </div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="symptoms" value="4" onChange={handleCheckboxChange} checked={formData.symptoms.includes('4')} />
-              <label className="form-check-label">腹痛</label>
-            </div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="symptoms" value="6" onChange={handleCheckboxChange} checked={formData.symptoms.includes('6')} />
-              <label className="form-check-label">発熱</label>
-            </div>
-          </div>
-        </div>
-        <div className="mb-3">
-          <label className="form-label">症状の期間</label>
-          <select
-            className="form-select"
-            name="duration"
-            value={formData.duration}
-            onChange={handleInputChange}
-          >
-            <option value="1">1日以内</option>
-            <option value="2">2-3日</option>
-            <option value="3">1週間以上</option>
-          </select>
-        </div>
-        <div className="mb-3">
-          <label className="form-label">既往歴</label>
-          <div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="history" value="8" onChange={handleCheckboxChange} checked={formData.history.includes('8')} />
-              <label className="form-check-label">高血圧</label>
-            </div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="history" value="1" onChange={handleCheckboxChange} checked={formData.history.includes('1')} />
-              <label className="form-check-label">糖尿病</label>
-            </div>
-            <div className="form-check form-check-inline">
-              <input className="form-check-input" type="checkbox" name="history" value="2" onChange={handleCheckboxChange} checked={formData.history.includes('2')} />
-              <label className="form-check-label">心臓病</label>
-            </div>
-          </div>
-        </div>
-        <div className="mb-3">
-          <label className="form-label">自由記述</label>
-          <input
-            type="text"
-            className="form-control"
-            name="freeText"
-            value={formData.freeText}
-            onChange={handleInputChange}
-            maxLength={300}
-          />
-        </div>
-      </form>
-
+      <div className="mb-3">
+        <label className="form-label">診療科</label>
+        <select
+          className="form-select"
+          value={departmentId}
+          onChange={(e) => setDepartmentId(e.target.value)}
+        >
+          <option value="">選択してください</option>
+          {Object.entries(departmentMap).map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+      {currentTemplate && (
+        <form>
+          {currentTemplate.fields.map((field) => renderField(field))}
+        </form>
+      )}
       <div className="mt-5">
         <h2>生成されたQRコード</h2>
-        {qrData && (
-          <canvas ref={qrCanvasRef}></canvas>
-        )}
-
-        {/* --- テスト用: 本番環境デプロイ前に必ず削除すること --- */}
+        {qrData && <canvas ref={qrCanvasRef}></canvas>}
         {qrData && (
           <div className="mt-3">
             <h3>QRコードデータ (テスト用)</h3>
-            <textarea
-              className="form-control"
-              rows={5}
-              readOnly
-              value={qrData}
-              style={{ fontSize: '0.8em' }}
-            ></textarea>
+            <textarea className="form-control" rows={5} readOnly value={qrData} style={{ fontSize: '0.8em' }}></textarea>
             <small className="text-danger">※この表示はテスト用です。本番環境デプロイ前に必ず削除してください。</small>
           </div>
         )}
-        {/* --- テスト用ここまで --- */}
       </div>
     </div>
   );
 };
 
 export default App;
-

--- a/input-app/src/templates.ts
+++ b/input-app/src/templates.ts
@@ -1,0 +1,80 @@
+export interface Option {
+  value: string;
+  label: string;
+}
+
+export interface Field {
+  name: string;
+  label: string;
+  type: 'text' | 'number' | 'select' | 'checkbox';
+  options?: Option[];
+}
+
+export interface Template {
+  departmentName: string;
+  fields: Field[];
+}
+
+export const departmentMap: { [id: string]: string } = {
+  '1': '内科',
+  '2': '外科',
+  '3': '小児科',
+  '4': '整形外科',
+};
+
+const baseFields: Field[] = [
+  { name: 'name', label: '氏名', type: 'text' },
+  { name: 'birthYear', label: '生年月日（年）', type: 'number' },
+  { name: 'birthMonth', label: '月', type: 'number' },
+  { name: 'birthDay', label: '日', type: 'number' },
+  { name: 'age', label: '年齢', type: 'number' },
+  {
+    name: 'gender',
+    label: '性別',
+    type: 'select',
+    options: [
+      { value: '1', label: '男性' },
+      { value: '2', label: '女性' },
+      { value: '3', label: 'その他' },
+    ],
+  },
+  {
+    name: 'symptoms',
+    label: '症状',
+    type: 'checkbox',
+    options: [
+      { value: '3', label: '頭痛' },
+      { value: '4', label: '腹痛' },
+      { value: '6', label: '発熱' },
+    ],
+  },
+  {
+    name: 'duration',
+    label: '症状の期間',
+    type: 'select',
+    options: [
+      { value: '1', label: '1日以内' },
+      { value: '2', label: '2-3日' },
+      { value: '3', label: '1週間以上' },
+    ],
+  },
+  {
+    name: 'history',
+    label: '既往歴',
+    type: 'checkbox',
+    options: [
+      { value: '8', label: '高血圧' },
+      { value: '1', label: '糖尿病' },
+      { value: '2', label: '心臓病' },
+    ],
+  },
+  { name: 'freeText', label: '自由記述', type: 'text' },
+];
+
+export const templates: { [id: string]: Template } = {
+  '1': { departmentName: departmentMap['1'], fields: baseFields },
+  '2': { departmentName: departmentMap['2'], fields: baseFields },
+  '3': { departmentName: departmentMap['3'], fields: baseFields },
+  '4': { departmentName: departmentMap['4'], fields: baseFields },
+};
+

--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -1,65 +1,21 @@
 import React, { useState } from 'react';
 import pako from 'pako';
 import CryptoJS from 'crypto-js';
-import * as encoding from 'encoding-japanese'; // encoding-japaneseライブラリ全体をインポート
-
-// --- DEBUG START: DO NOT DEPLOY TO PRODUCTION ---
-// このコードは、ブラウザのコンソールからCryptoJS, pako, encoding-japaneseにアクセスできるように、
-// グローバルなwindowオブジェクトにライブラリを露出させます。
-// 本番環境にデプロイする前に、必ずこのブロックを削除してください。
-declare global {
-  interface Window {
-    CryptoJS: typeof CryptoJS;
-    pako: typeof pako;
-    encoding: typeof encoding;
-  }
-}
-window.CryptoJS = CryptoJS;
-window.pako = pako;
-window.encoding = encoding;
-// --- DEBUG END ---
+import * as encoding from 'encoding-japanese';
+import { templates, departmentMap } from './templates';
+import type { Field } from './templates';
 
 const App: React.FC = () => {
   const [qrData, setQrData] = useState('');
-  const [restoredData, setRestoredData] = useState<string[]>([]);
+  const [restoredData, setRestoredData] = useState<Record<string, string>>({});
+  const [departmentId, setDepartmentId] = useState('');
   const [error, setError] = useState('');
 
-  // IDとラベルのマッピング
-  const genderMap: { [key: string]: string } = {
-    '1': '男性',
-    '2': '女性',
-    '3': 'その他',
-  };
-
-  const symptomMap: { [key: string]: string } = {
-    '3': '頭痛',
-    '4': '腹痛',
-    '6': '発熱',
-  };
-
-  const durationMap: { [key: string]: string } = {
-    '1': '1日以内',
-    '2': '2-3日',
-    '3': '1週間以上',
-  };
-
-  const historyMap: { [key: string]: string } = {
-    '8': '高血圧',
-    '1': '糖尿病',
-    '2': '心臓病',
-  };
-
-  const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY; // 環境変数から読み込み
+  const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY;
 
   const handleRestore = () => {
-    console.log("handleRestore called.");
-    console.log("Input qrData:", qrData);
     try {
-      // 1. Base64 decode (CryptoJS does this automatically)
       const decrypted = CryptoJS.AES.decrypt(qrData, encryptionKey);
-      console.log("Decrypted sigBytes:", decrypted.sigBytes);
-
-      // Convert WordArray to Uint8Array
       const decryptedBytes = new Uint8Array(decrypted.words.length * 4);
       for (let i = 0; i < decrypted.words.length; i++) {
         decryptedBytes[i * 4] = (decrypted.words[i] >> 24) & 0xff;
@@ -67,55 +23,68 @@ const App: React.FC = () => {
         decryptedBytes[i * 4 + 2] = (decrypted.words[i] >> 8) & 0xff;
         decryptedBytes[i * 4 + 3] = decrypted.words[i] & 0xff;
       }
-
-      // Trim padding
       const trimmedBytes = decryptedBytes.slice(0, decrypted.sigBytes);
-      console.log("Trimmed bytes length:", trimmedBytes.length);
-
-      // 2. zlib decompression
       const decompressed = pako.inflate(trimmedBytes);
-      console.log("Decompressed data:", decompressed);
-
-      // 3. Decode from Shift_JIS
       const decoded = encoding.convert(decompressed, {
-        to: 'UNICODE', // UTF-8に相当
+        to: 'UNICODE',
         from: 'SJIS',
-        type: 'string'
+        type: 'string',
       });
-      console.log("Decoded string:", decoded);
+      const parsed = decoded.split(',');
+      const deptIdFromQr = parsed[0];
 
-      // 4. CSV parsing
-      const parsedData = decoded.split(',');
-      console.log("Parsed data:", parsedData);
+      if (departmentId && departmentId !== deptIdFromQr) {
+        setError('選択した診療科とQRコード内の診療科が一致しません');
+        setRestoredData({});
+        return;
+      }
+      setDepartmentId(deptIdFromQr);
 
-      setRestoredData(parsedData);
+      const template = templates[deptIdFromQr];
+      if (!template) {
+        setError('未知の診療科IDです');
+        return;
+      }
+
+      const dataPart = parsed.slice(1);
+      const obj: Record<string, string> = {};
+      template.fields.forEach((field, idx) => {
+        obj[field.name] = dataPart[idx] || '';
+      });
+      setRestoredData(obj);
       setError('');
-
     } catch (e) {
-      console.error("Error during restore process:", e);
-      setError('Failed to restore data. Please check the QR code and try again.');
-      setRestoredData([]);
+      console.error('Error during restore process:', e);
+      setError('復元に失敗しました');
+      setRestoredData({});
     }
   };
 
   const handleClear = () => {
     setQrData('');
-    setRestoredData([]);
+    setRestoredData({});
     setError('');
   };
 
+  const formatValue = (field: Field, value: string) => {
+    if (field.type === 'checkbox') {
+      return value
+        .split(';')
+        .map((v) => field.options?.find((o) => o.value === v)?.label || v)
+        .join(', ');
+    }
+    if (field.type === 'select') {
+      return field.options?.find((o) => o.value === value)?.label || value;
+    }
+    return value;
+  };
+
+  const currentTemplate = departmentId ? templates[departmentId] : undefined;
+
   const handleCopyToClipboard = () => {
-    const formattedText = `
-Name: ${restoredData[0]}
-Date of Birth: ${restoredData[1]}-${restoredData[2]}-${restoredData[3]}
-Age: ${restoredData[4]}
-Sex: ${restoredData[5] === '1' ? 'Male' : restoredData[5] === '2' ? 'Female' : 'Other'}
-Symptoms: ${restoredData[6]}
-Duration: ${restoredData[7]}
-History: ${restoredData[8]}
-Free Text: ${restoredData[9]}
-`;
-    navigator.clipboard.writeText(formattedText);
+    if (!currentTemplate) return;
+    const lines = currentTemplate.fields.map((f) => `${f.label}: ${formatValue(f, restoredData[f.name] || '')}`);
+    navigator.clipboard.writeText(lines.join('\n'));
     alert('Copied to clipboard!');
   };
 
@@ -123,13 +92,19 @@ Free Text: ${restoredData[9]}
     <div className="container mt-5">
       <h1>QR問診票復元</h1>
       <div className="mb-3">
+        <label className="form-label">診療科</label>
+        <select className="form-select" value={departmentId} onChange={(e) => setDepartmentId(e.target.value)}>
+          <option value="">選択してください</option>
+          {Object.entries(departmentMap).map(([id, name]) => (
+            <option key={id} value={id}>
+              {name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="mb-3">
         <label className="form-label">QRデータ</label>
-        <textarea
-          className="form-control"
-          rows={5}
-          value={qrData}
-          onChange={(e) => setQrData(e.target.value)}
-        ></textarea>
+        <textarea className="form-control" rows={5} value={qrData} onChange={(e) => setQrData(e.target.value)}></textarea>
       </div>
       <button className="btn btn-primary me-2" onClick={handleRestore}>
         復元
@@ -137,46 +112,18 @@ Free Text: ${restoredData[9]}
       <button className="btn btn-secondary" onClick={handleClear}>
         クリア
       </button>
-
       {error && <div className="alert alert-danger mt-3">{error}</div>}
-
-      {restoredData.length > 0 && (
+      {currentTemplate && Object.keys(restoredData).length > 0 && (
         <div className="mt-5">
           <h2>復元された問診データ</h2>
           <table className="table table-bordered">
             <tbody>
-              <tr>
-                <th>氏名</th>
-                <td>{restoredData[0]}</td>
-              </tr>
-              <tr>
-                <th>生年月日</th>
-                <td>{`${restoredData[1]}年${restoredData[2]}月${restoredData[3]}日`}</td>
-              </tr>
-              <tr>
-                <th>年齢</th>
-                <td>{restoredData[4]}</td>
-              </tr>
-              <tr>
-                <th>性別</th>
-                <td>{genderMap[restoredData[5]] || restoredData[5]}</td>
-              </tr>
-              <tr>
-                <th>症状</th>
-                <td>{restoredData[6].split(';').map(id => symptomMap[id] || id).join(', ')}</td>
-              </tr>
-              <tr>
-                <th>症状の期間</th>
-                <td>{durationMap[restoredData[7]] || restoredData[7]}</td>
-              </tr>
-              <tr>
-                <th>既往歴</th>
-                <td>{restoredData[8].split(';').map(id => historyMap[id] || id).join(', ')}</td>
-              </tr>
-              <tr>
-                <th>自由記述</th>
-                <td>{restoredData[9]}</td>
-              </tr>
+              {currentTemplate.fields.map((field) => (
+                <tr key={field.name}>
+                  <th>{field.label}</th>
+                  <td>{formatValue(field, restoredData[field.name] || '')}</td>
+                </tr>
+              ))}
             </tbody>
           </table>
           <button className="btn btn-info mt-3" onClick={handleCopyToClipboard}>

--- a/restore-app/src/templates.ts
+++ b/restore-app/src/templates.ts
@@ -1,0 +1,80 @@
+export interface Option {
+  value: string;
+  label: string;
+}
+
+export interface Field {
+  name: string;
+  label: string;
+  type: 'text' | 'number' | 'select' | 'checkbox';
+  options?: Option[];
+}
+
+export interface Template {
+  departmentName: string;
+  fields: Field[];
+}
+
+export const departmentMap: { [id: string]: string } = {
+  '1': '内科',
+  '2': '外科',
+  '3': '小児科',
+  '4': '整形外科',
+};
+
+const baseFields: Field[] = [
+  { name: 'name', label: '氏名', type: 'text' },
+  { name: 'birthYear', label: '生年月日（年）', type: 'number' },
+  { name: 'birthMonth', label: '月', type: 'number' },
+  { name: 'birthDay', label: '日', type: 'number' },
+  { name: 'age', label: '年齢', type: 'number' },
+  {
+    name: 'gender',
+    label: '性別',
+    type: 'select',
+    options: [
+      { value: '1', label: '男性' },
+      { value: '2', label: '女性' },
+      { value: '3', label: 'その他' },
+    ],
+  },
+  {
+    name: 'symptoms',
+    label: '症状',
+    type: 'checkbox',
+    options: [
+      { value: '3', label: '頭痛' },
+      { value: '4', label: '腹痛' },
+      { value: '6', label: '発熱' },
+    ],
+  },
+  {
+    name: 'duration',
+    label: '症状の期間',
+    type: 'select',
+    options: [
+      { value: '1', label: '1日以内' },
+      { value: '2', label: '2-3日' },
+      { value: '3', label: '1週間以上' },
+    ],
+  },
+  {
+    name: 'history',
+    label: '既往歴',
+    type: 'checkbox',
+    options: [
+      { value: '8', label: '高血圧' },
+      { value: '1', label: '糖尿病' },
+      { value: '2', label: '心臓病' },
+    ],
+  },
+  { name: 'freeText', label: '自由記述', type: 'text' },
+];
+
+export const templates: { [id: string]: Template } = {
+  '1': { departmentName: departmentMap['1'], fields: baseFields },
+  '2': { departmentName: departmentMap['2'], fields: baseFields },
+  '3': { departmentName: departmentMap['3'], fields: baseFields },
+  '4': { departmentName: departmentMap['4'], fields: baseFields },
+};
+


### PR DESCRIPTION
## Summary
- support department-specific templates
- embed department ID in QR payload
- validate department on restore and show warnings
- ignore build output directories

## Testing
- `npm run lint` in input-app
- `npm run build` in input-app
- `npm run lint` in restore-app
- `npm run build` in restore-app

------
https://chatgpt.com/codex/tasks/task_e_6861e67af6448323b1edc6338dd3156c