### PR TITLE
Load templates from JSON

### DIFF
--- a/input-app/public/templates/1.json
+++ b/input-app/public/templates/1.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 1,
+  "department_name": "内科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/input-app/public/templates/2.json
+++ b/input-app/public/templates/2.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 2,
+  "department_name": "外科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/input-app/public/templates/3.json
+++ b/input-app/public/templates/3.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 3,
+  "department_name": "小児科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/input-app/public/templates/4.json
+++ b/input-app/public/templates/4.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 4,
+  "department_name": "整形外科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -3,29 +3,37 @@ import QRCode from 'qrcode';
 import pako from 'pako';
 import CryptoJS from 'crypto-js';
 import * as Encoding from 'encoding-japanese';
-import { templates, departmentMap } from './templates';
-import type { Field } from './templates';
+import { departmentMap } from './templates';
+import type { Template, Question } from './templates';
 
 const App: React.FC = () => {
   const [departmentId, setDepartmentId] = useState('');
   const [formData, setFormData] = useState<Record<string, string | string[]>>({});
   const [qrData, setQrData] = useState('');
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [loading, setLoading] = useState(false);
   const qrCanvasRef = useRef<HTMLCanvasElement>(null);
 
   const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY;
 
   useEffect(() => {
-    if (!departmentId) {
+    if (!departmentId || !template) {
       setQrData('');
       return;
     }
-    const template = templates[departmentId];
-    if (!template) return;
+
     const csvData = [
       departmentId,
-      ...template.fields.map((field: Field) => {
-        const val = formData[field.name];
-        if (field.type === 'checkbox') {
+      ...template.questions.map((q: Question) => {
+        const val = formData[q.id];
+        if (q.type === 'multi_select') {
+          if (q.bitflag) {
+            const arr = Array.isArray(val) ? val : [];
+            return arr.reduce(
+              (acc, v) => acc | (1 << (parseInt(v as string, 10) - 1)),
+              0
+            );
+          }
           return Array.isArray(val) ? val.join(';') : '';
         }
         return val ?? '';
@@ -40,7 +48,7 @@ const App: React.FC = () => {
     ).toString();
 
     setQrData(encrypted);
-  }, [formData, departmentId]);
+  }, [formData, departmentId, template, encryptionKey]);
 
   useEffect(() => {
     if (qrCanvasRef.current && qrData) {
@@ -51,18 +59,33 @@ const App: React.FC = () => {
   }, [qrData]);
 
   useEffect(() => {
-    if (departmentId) {
-      const initial: Record<string, string | string[]> = {};
-      templates[departmentId].fields.forEach((f) => {
-        initial[f.name] = f.type === 'checkbox' ? [] : '';
-      });
-      setFormData(initial);
-    } else {
+    if (!departmentId) {
+      setTemplate(null);
       setFormData({});
+      return;
     }
+    setLoading(true);
+    fetch(`/templates/${departmentId}.json`)
+      .then((res) => res.json())
+      .then((data: Template) => {
+        setTemplate(data);
+        const initial: Record<string, string | string[]> = {};
+        data.questions.forEach((q) => {
+          initial[q.id] = q.type === 'multi_select' ? [] : '';
+        });
+        setFormData(initial);
+      })
+      .catch((err) => {
+        console.error(err);
+        setTemplate(null);
+        setFormData({});
+      })
+      .finally(() => setLoading(false));
   }, [departmentId]);
 
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+  const handleInputChange = (
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
+  ) => {
     const { name, value } = e.target;
     setFormData({ ...formData, [name]: value });
   };
@@ -77,55 +100,55 @@ const App: React.FC = () => {
     }
   };
 
-  const renderField = (field: Field) => {
+  const renderField = (field: Question) => {
     switch (field.type) {
       case 'text':
       case 'number':
         return (
-          <div className="mb-3" key={field.name}>
+          <div className="mb-3" key={field.id}>
             <label className="form-label">{field.label}</label>
             <input
-              type={field.type === 'number' ? 'number' : 'text'}
+              type={field.type === 'number' ? 'number' : field.type}
               className="form-control"
-              name={field.name}
-              value={formData[field.name] || ''}
+              name={field.id}
+              value={formData[field.id] || ''}
               onChange={handleInputChange}
-              maxLength={field.name === 'freeText' ? 300 : undefined}
+              maxLength={field.id === 'freeText' ? 300 : undefined}
             />
           </div>
         );
       case 'select':
         return (
-          <div className="mb-3" key={field.name}>
+          <div className="mb-3" key={field.id}>
             <label className="form-label">{field.label}</label>
             <select
               className="form-select"
-              name={field.name}
-              value={formData[field.name] || ''}
+              name={field.id}
+              value={formData[field.id] || ''}
               onChange={handleInputChange}
             >
               {field.options?.map((opt) => (
-                <option key={opt.value} value={opt.value}>
+                <option key={opt.id} value={opt.id}>
                   {opt.label}
                 </option>
               ))}
             </select>
           </div>
         );
-      case 'checkbox':
+      case 'multi_select':
         return (
-          <div className="mb-3" key={field.name}>
+          <div className="mb-3" key={field.id}>
             <label className="form-label">{field.label}</label>
             <div>
               {field.options?.map((opt) => (
-                <div className="form-check form-check-inline" key={opt.value}>
+                <div className="form-check form-check-inline" key={opt.id}>
                   <input
                     className="form-check-input"
                     type="checkbox"
-                    name={field.name}
-                    value={opt.value}
+                    name={field.id}
+                    value={opt.id}
                     onChange={handleCheckboxChange}
-                    checked={(formData[field.name] || []).includes(opt.value)}
+                    checked={(formData[field.id] || []).includes(opt.id)}
                   />
                   <label className="form-check-label">{opt.label}</label>
                 </div>
@@ -133,12 +156,23 @@ const App: React.FC = () => {
             </div>
           </div>
         );
+      case 'date':
+        return (
+          <div className="mb-3" key={field.id}>
+            <label className="form-label">{field.label}</label>
+            <input
+              type="date"
+              className="form-control"
+              name={field.id}
+              value={formData[field.id] || ''}
+              onChange={handleInputChange}
+            />
+          </div>
+        );
       default:
         return null;
     }
   };
-
-  const currentTemplate = departmentId ? templates[departmentId] : undefined;
 
   if (!departmentId) {
     return (
@@ -165,9 +199,10 @@ const App: React.FC = () => {
   return (
     <div className="container mt-5">
       <h1>QR問診票入力 - {departmentMap[departmentId]}</h1>
-      {currentTemplate && (
+      {loading && <p>Loading...</p>}
+      {template && !loading && (
         <form>
-          {currentTemplate.fields.map((field) => renderField(field))}
+          {template.questions.map((field) => renderField(field))}
         </form>
       )}
       <div className="mt-5">

--- a/input-app/src/templates.ts
+++ b/input-app/src/templates.ts
@@ -1,18 +1,20 @@
 export interface Option {
-  value: string;
+  id: string | number;
   label: string;
 }
 
-export interface Field {
-  name: string;
+export interface Question {
+  id: string;
   label: string;
-  type: 'text' | 'number' | 'select' | 'checkbox';
+  type: string;
   options?: Option[];
+  bitflag?: boolean;
 }
 
 export interface Template {
-  departmentName: string;
-  fields: Field[];
+  department_id: number;
+  department_name: string;
+  questions: Question[];
 }
 
 export const departmentMap: { [id: string]: string } = {
@@ -20,61 +22,5 @@ export const departmentMap: { [id: string]: string } = {
   '2': '外科',
   '3': '小児科',
   '4': '整形外科',
-};
-
-const baseFields: Field[] = [
-  { name: 'name', label: '氏名', type: 'text' },
-  { name: 'birthYear', label: '生年月日（年）', type: 'number' },
-  { name: 'birthMonth', label: '月', type: 'number' },
-  { name: 'birthDay', label: '日', type: 'number' },
-  { name: 'age', label: '年齢', type: 'number' },
-  {
-    name: 'gender',
-    label: '性別',
-    type: 'select',
-    options: [
-      { value: '1', label: '男性' },
-      { value: '2', label: '女性' },
-      { value: '3', label: 'その他' },
-    ],
-  },
-  {
-    name: 'symptoms',
-    label: '症状',
-    type: 'checkbox',
-    options: [
-      { value: '3', label: '頭痛' },
-      { value: '4', label: '腹痛' },
-      { value: '6', label: '発熱' },
-    ],
-  },
-  {
-    name: 'duration',
-    label: '症状の期間',
-    type: 'select',
-    options: [
-      { value: '1', label: '1日以内' },
-      { value: '2', label: '2-3日' },
-      { value: '3', label: '1週間以上' },
-    ],
-  },
-  {
-    name: 'history',
-    label: '既往歴',
-    type: 'checkbox',
-    options: [
-      { value: '8', label: '高血圧' },
-      { value: '1', label: '糖尿病' },
-      { value: '2', label: '心臓病' },
-    ],
-  },
-  { name: 'freeText', label: '自由記述', type: 'text' },
-];
-
-export const templates: { [id: string]: Template } = {
-  '1': { departmentName: departmentMap['1'], fields: baseFields },
-  '2': { departmentName: departmentMap['2'], fields: baseFields },
-  '3': { departmentName: departmentMap['3'], fields: baseFields },
-  '4': { departmentName: departmentMap['4'], fields: baseFields },
 };
 

--- a/restore-app/public/templates/1.json
+++ b/restore-app/public/templates/1.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 1,
+  "department_name": "内科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/restore-app/public/templates/2.json
+++ b/restore-app/public/templates/2.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 2,
+  "department_name": "外科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/restore-app/public/templates/3.json
+++ b/restore-app/public/templates/3.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 3,
+  "department_name": "小児科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/restore-app/public/templates/4.json
+++ b/restore-app/public/templates/4.json
@@ -1,0 +1,112 @@
+{
+  "department_id": 4,
+  "department_name": "整形外科",
+  "questions": [
+    {
+      "id": "name",
+      "label": "氏名",
+      "type": "text"
+    },
+    {
+      "id": "birthYear",
+      "label": "生年月日（年）",
+      "type": "number"
+    },
+    {
+      "id": "birthMonth",
+      "label": "月",
+      "type": "number"
+    },
+    {
+      "id": "birthDay",
+      "label": "日",
+      "type": "number"
+    },
+    {
+      "id": "age",
+      "label": "年齢",
+      "type": "number"
+    },
+    {
+      "id": "gender",
+      "label": "性別",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "男性"
+        },
+        {
+          "id": "2",
+          "label": "女性"
+        },
+        {
+          "id": "3",
+          "label": "その他"
+        }
+      ]
+    },
+    {
+      "id": "symptoms",
+      "label": "症状",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "3",
+          "label": "頭痛"
+        },
+        {
+          "id": "4",
+          "label": "腹痛"
+        },
+        {
+          "id": "6",
+          "label": "発熱"
+        }
+      ]
+    },
+    {
+      "id": "duration",
+      "label": "症状の期間",
+      "type": "select",
+      "options": [
+        {
+          "id": "1",
+          "label": "1日以内"
+        },
+        {
+          "id": "2",
+          "label": "2-3日"
+        },
+        {
+          "id": "3",
+          "label": "1週間以上"
+        }
+      ]
+    },
+    {
+      "id": "history",
+      "label": "既往歴",
+      "type": "multi_select",
+      "options": [
+        {
+          "id": "8",
+          "label": "高血圧"
+        },
+        {
+          "id": "1",
+          "label": "糖尿病"
+        },
+        {
+          "id": "2",
+          "label": "心臓病"
+        }
+      ]
+    },
+    {
+      "id": "freeText",
+      "label": "自由記述",
+      "type": "text"
+    }
+  ]
+}

--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -1,15 +1,17 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import pako from 'pako';
 import CryptoJS from 'crypto-js';
 import * as encoding from 'encoding-japanese';
-import { templates, departmentMap } from './templates';
-import type { Field } from './templates';
+import { departmentMap } from './templates';
+import type { Template, Question } from './templates';
 
 const App: React.FC = () => {
   const [qrData, setQrData] = useState('');
   const [restoredData, setRestoredData] = useState<Record<string, string>>({});
   const [departmentId, setDepartmentId] = useState('');
   const [error, setError] = useState('');
+  const [template, setTemplate] = useState<Template | null>(null);
+  const [loading, setLoading] = useState(false);
 
   const encryptionKey = import.meta.env.VITE_ENCRYPTION_KEY;
 
@@ -43,16 +45,27 @@ const App: React.FC = () => {
         return;
       }
 
-      const template = templates[departmentId];
       if (!template) {
-        setError('未知の診療科IDです');
+        setError('テンプレートの読み込みに失敗しました');
         return;
       }
 
       const dataPart = parsed.slice(1);
       const obj: Record<string, string> = {};
-      template.fields.forEach((field, idx) => {
-        obj[field.name] = dataPart[idx] || '';
+      template.questions.forEach((field, idx) => {
+        let value = dataPart[idx] || '';
+        if (field.type === 'multi_select') {
+          if (field.bitflag) {
+            const num = parseInt(value, 10);
+            const selected: string[] = [];
+            field.options?.forEach((opt) => {
+              const bit = 1 << (parseInt(opt.id as string, 10) - 1);
+              if (num & bit) selected.push(String(opt.id));
+            });
+            value = selected.join(';');
+          }
+        }
+        obj[field.id] = value;
       });
       setRestoredData(obj);
       setError('');
@@ -69,31 +82,54 @@ const App: React.FC = () => {
     setError('');
   };
 
-  const formatValue = (field: Field, value: string) => {
-    if (field.type === 'checkbox') {
+  useEffect(() => {
+    if (!departmentId) {
+      setTemplate(null);
+      setRestoredData({});
+      return;
+    }
+    setLoading(true);
+    fetch(`/templates/${departmentId}.json`)
+      .then((res) => res.json())
+      .then((data: Template) => {
+        setTemplate(data);
+        setRestoredData({});
+      })
+      .catch((err) => {
+        console.error(err);
+        setTemplate(null);
+        setRestoredData({});
+      })
+      .finally(() => setLoading(false));
+  }, [departmentId]);
+
+  const formatValue = (field: Question, value: string) => {
+    if (field.type === 'multi_select') {
       return value
         .split(';')
-        .map((v) => field.options?.find((o) => o.value === v)?.label || v)
+        .map((v) => field.options?.find((o) => String(o.id) === v)?.label || v)
         .join(', ');
     }
     if (field.type === 'select') {
-      return field.options?.find((o) => o.value === value)?.label || value;
+      return field.options?.find((o) => String(o.id) === value)?.label || value;
     }
     return value;
   };
 
-  const currentTemplate = departmentId ? templates[departmentId] : undefined;
-
   const handleCopyToClipboard = () => {
-    if (!currentTemplate) return;
-    const lines = currentTemplate.fields.map((f) => `${f.label}: ${formatValue(f, restoredData[f.name] || '')}`);
+    if (!template) return;
+    const lines = template.questions.map(
+      (f) => `${f.label}: ${formatValue(f, restoredData[f.id] || '')}`
+    );
     navigator.clipboard.writeText(lines.join('\n'));
     alert('Copied to clipboard!');
   };
 
   const handleDownloadTxt = () => {
-    if (!currentTemplate) return;
-    const lines = currentTemplate.fields.map((f) => `${f.label}: ${formatValue(f, restoredData[f.name] || '')}`);
+    if (!template) return;
+    const lines = template.questions.map(
+      (f) => `${f.label}: ${formatValue(f, restoredData[f.id] || '')}`
+    );
     const blob = new Blob([lines.join('\n')], { type: 'text/plain' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');
@@ -124,6 +160,7 @@ const App: React.FC = () => {
   return (
     <div className="container mt-5">
       <h1>QR問診票復元 - {departmentMap[departmentId]}</h1>
+      {loading && <p>Loading...</p>}
       <div className="mb-3">
         <label className="form-label">QRデータ</label>
         <textarea className="form-control" rows={5} value={qrData} onChange={(e) => setQrData(e.target.value)}></textarea>
@@ -135,15 +172,15 @@ const App: React.FC = () => {
         クリア
       </button>
       {error && <div className="alert alert-danger mt-3">{error}</div>}
-      {currentTemplate && Object.keys(restoredData).length > 0 && (
+      {template && Object.keys(restoredData).length > 0 && (
         <div className="mt-5">
           <h2>復元された問診データ</h2>
           <table className="table table-bordered">
             <tbody>
-              {currentTemplate.fields.map((field) => (
-                <tr key={field.name}>
+              {template.questions.map((field) => (
+                <tr key={field.id}>
                   <th>{field.label}</th>
-                  <td>{formatValue(field, restoredData[field.name] || '')}</td>
+                  <td>{formatValue(field, restoredData[field.id] || '')}</td>
                 </tr>
               ))}
             </tbody>

--- a/restore-app/src/templates.ts
+++ b/restore-app/src/templates.ts
@@ -1,18 +1,20 @@
 export interface Option {
-  value: string;
+  id: string | number;
   label: string;
 }
 
-export interface Field {
-  name: string;
+export interface Question {
+  id: string;
   label: string;
-  type: 'text' | 'number' | 'select' | 'checkbox';
+  type: string;
   options?: Option[];
+  bitflag?: boolean;
 }
 
 export interface Template {
-  departmentName: string;
-  fields: Field[];
+  department_id: number;
+  department_name: string;
+  questions: Question[];
 }
 
 export const departmentMap: { [id: string]: string } = {
@@ -20,61 +22,5 @@ export const departmentMap: { [id: string]: string } = {
   '2': '外科',
   '3': '小児科',
   '4': '整形外科',
-};
-
-const baseFields: Field[] = [
-  { name: 'name', label: '氏名', type: 'text' },
-  { name: 'birthYear', label: '生年月日（年）', type: 'number' },
-  { name: 'birthMonth', label: '月', type: 'number' },
-  { name: 'birthDay', label: '日', type: 'number' },
-  { name: 'age', label: '年齢', type: 'number' },
-  {
-    name: 'gender',
-    label: '性別',
-    type: 'select',
-    options: [
-      { value: '1', label: '男性' },
-      { value: '2', label: '女性' },
-      { value: '3', label: 'その他' },
-    ],
-  },
-  {
-    name: 'symptoms',
-    label: '症状',
-    type: 'checkbox',
-    options: [
-      { value: '3', label: '頭痛' },
-      { value: '4', label: '腹痛' },
-      { value: '6', label: '発熱' },
-    ],
-  },
-  {
-    name: 'duration',
-    label: '症状の期間',
-    type: 'select',
-    options: [
-      { value: '1', label: '1日以内' },
-      { value: '2', label: '2-3日' },
-      { value: '3', label: '1週間以上' },
-    ],
-  },
-  {
-    name: 'history',
-    label: '既往歴',
-    type: 'checkbox',
-    options: [
-      { value: '8', label: '高血圧' },
-      { value: '1', label: '糖尿病' },
-      { value: '2', label: '心臓病' },
-    ],
-  },
-  { name: 'freeText', label: '自由記述', type: 'text' },
-];
-
-export const templates: { [id: string]: Template } = {
-  '1': { departmentName: departmentMap['1'], fields: baseFields },
-  '2': { departmentName: departmentMap['2'], fields: baseFields },
-  '3': { departmentName: departmentMap['3'], fields: baseFields },
-  '4': { departmentName: departmentMap['4'], fields: baseFields },
 };
 


### PR DESCRIPTION
## Summary
- add questionnaire templates as JSON files
- fetch template JSON for selected department
- render questions dynamically in input and restore apps
- parse multi-select and bitflag answers

## Testing
- `npm run lint` in `input-app`
- `npm run lint` in `restore-app`


------
https://chatgpt.com/codex/tasks/task_e_6861f8ea2fc08323a8ffef860c7d03f1