### PR TITLE
Fix checkbox includes type error

### DIFF
--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -146,9 +146,9 @@ const App: React.FC = () => {
                     className="form-check-input"
                     type="checkbox"
                     name={field.id}
-                    value={opt.id}
+                    value={String(opt.id)}
                     onChange={handleCheckboxChange}
-                    checked={(formData[field.id] || []).includes(opt.id)}
+                    checked={(formData[field.id] || []).includes(String(opt.id))}
                   />
                   <label className="form-check-label">{opt.label}</label>
                 </div>


### PR DESCRIPTION
## Summary
- fix checkbox id comparison by converting to strings

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68620ab19bac8323a755c481215dc4c0