### PR TITLE
Fix UTF-8 encoding for btoa usage

### DIFF
--- a/input-app/src/shared/crypto.ts
+++ b/input-app/src/shared/crypto.ts
@@ -1,7 +1,13 @@
 export function encrypt(data: string): string {
-  return btoa(data);
+  const bytes = new TextEncoder().encode(data);
+  const binary = Array.from(bytes)
+    .map((b) => String.fromCharCode(b))
+    .join('');
+  return btoa(binary);
 }
 
 export function decrypt(data: string): string {
-  return atob(data);
+  const binary = atob(data);
+  const bytes = new Uint8Array([...binary].map((c) => c.charCodeAt(0)));
+  return new TextDecoder().decode(bytes);
 }

--- a/restore-app/src/crypto.ts
+++ b/restore-app/src/crypto.ts
@@ -1,6 +1,8 @@
 export function decryptCsv(data: string, _key: string): string {
   try {
-    const decoded = atob(data);
+    const binary = atob(data);
+    const bytes = new Uint8Array([...binary].map((c) => c.charCodeAt(0)));
+    const decoded = new TextDecoder().decode(bytes);
     return decoded;
   } catch (e) {
     console.error('decryptCsv failed', e);
@@ -10,7 +12,11 @@ export function decryptCsv(data: string, _key: string): string {
 
 export function encryptCsv(data: string, _key: string): string {
   try {
-    return btoa(data);
+    const bytes = new TextEncoder().encode(data);
+    const binary = Array.from(bytes)
+      .map((b) => String.fromCharCode(b))
+      .join('');
+    return btoa(binary);
   } catch (e) {
     console.error('encryptCsv failed', e);
     return '';


### PR DESCRIPTION
## Summary
- ensure base64 encoding handles UTF-8 data
- same for restore app

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` in input-app *(fails: Cannot find module 'react')*
- `npm run build` in restore-app *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686369359a008323bdbb2be8a30a5f0c