### PR TITLE
Implement encryption/QR utilities

### DIFF
--- a/input-app/src/logic/encodeAndEncrypt.ts
+++ b/input-app/src/logic/encodeAndEncrypt.ts
@@ -1,0 +1,48 @@
+import pako from 'pako';
+import * as Encoding from 'encoding-japanese';
+
+function pemToArrayBuffer(pem: string): ArrayBuffer {
+  const b64 = pem
+    .replace('-----BEGIN PUBLIC KEY-----', '')
+    .replace('-----END PUBLIC KEY-----', '')
+    .replace(/\s+/g, '');
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes.buffer;
+}
+
+export async function encodeAndEncrypt(
+  csv: string,
+  publicKeyPem: string
+): Promise<Uint8Array> {
+  const sjisArray = Encoding.convert(
+    Encoding.stringToCode(csv),
+    'SJIS',
+    'UNICODE'
+  ) as number[];
+
+  const sjisUint8 = new Uint8Array(sjisArray);
+
+  const compressed = pako.deflate(sjisUint8);
+
+  const cryptoKey = await crypto.subtle.importKey(
+    'spki',
+    pemToArrayBuffer(publicKeyPem),
+    { name: 'RSA-OAEP', hash: 'SHA-256' },
+    false,
+    ['encrypt']
+  );
+
+  const encrypted = await crypto.subtle.encrypt(
+    { name: 'RSA-OAEP' },
+    cryptoKey,
+    compressed
+  );
+
+  return new Uint8Array(encrypted);
+}
+
+export { pemToArrayBuffer };

--- a/input-app/src/logic/qrGenerator.ts
+++ b/input-app/src/logic/qrGenerator.ts
@@ -1,0 +1,13 @@
+import QRCode from 'qrcode';
+
+export async function generateQrFromEncrypted(
+  encryptedData: Uint8Array,
+  canvasEl: HTMLCanvasElement
+) {
+  const b64 = btoa(String.fromCharCode(...encryptedData));
+  await QRCode.toCanvas(canvasEl, b64, {
+    errorCorrectionLevel: 'M',
+    width: 300,
+    margin: 2,
+  });
+}


### PR DESCRIPTION
## Summary
- add encode-and-encrypt helper using Shift_JIS, pako and RSA
- add QR generator utility for encrypted bytes

## Testing
- `npm run lint` in `input-app`
- `npm run build` in `input-app`


------
https://chatgpt.com/codex/tasks/task_e_686388c68d98832380fff46222dfd305