### PR TITLE
Align error messages with tech spec

### DIFF
--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -22,7 +22,9 @@ const App: React.FC = () => {
     fetchPublicKey()
       .then((key) => setPublicKey(key))
       .catch(() =>
-        setError('通信に失敗しました。オフライン環境ではご利用いただけません。')
+        setError(
+          'サーバーとの通信に失敗しました。通信環境の良い場所でページを再読み込みしてください。'
+        )
       );
   }, []);
 
@@ -66,7 +68,9 @@ const App: React.FC = () => {
       }
     } catch (err) {
       console.error(err);
-      setError('QRコードの生成に失敗しました。通信環境をご確認ください。');
+      setError(
+        'QRコードの生成に失敗しました。お手数ですが、最初からやり直してください。'
+      );
     }
   };
 

--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -15,7 +15,13 @@ const App: React.FC = () => {
       setError('');
     } catch (e) {
       console.error(e);
-      setError('QRコードの復号に失敗しました。再度読み取りをお試しください。');
+      if (e instanceof Error && e.message) {
+        setError(e.message);
+      } else {
+        setError(
+          '復号に失敗しました。有効期間外のQRコードである可能性があります。患者様にご確認ください。'
+        );
+      }
       setResult([]);
     }
   };

--- a/restore-app/src/api.ts
+++ b/restore-app/src/api.ts
@@ -5,12 +5,16 @@ export async function decryptQr(data: string): Promise<string> {
     body: JSON.stringify({ data })
   });
 
+  const json = await res.json().catch(() => ({}));
+
   if (!res.ok) {
-    throw new Error('decrypt failed');
+    const msg = typeof json.error === 'string' ? json.error : 'decrypt failed';
+    throw new Error(msg);
   }
-  const json = await res.json();
+
   if (!json.csv) {
     throw new Error('decrypt failed');
   }
+
   return json.csv as string;
 }

--- a/restore-server/src/server.ts
+++ b/restore-server/src/server.ts
@@ -59,7 +59,13 @@ app.post('/api/decrypt', (req, res) => {
     res.json({ csv });
   } catch (err) {
     logger.error(err);
-    res.status(400).json({ error: '復元に失敗しました。再度お試しください。' });
+    let message =
+      'このQRコードは読み取れません。QRコードが欠けていないか、有効なものか確認してください。';
+    if ((err as any)?.code === 'ERR_OSSL_EVP_BAD_DECRYPT') {
+      message =
+        '復号に失敗しました。有効期間外のQRコードである可能性があります。患者様にご確認ください。';
+    }
+    res.status(400).json({ error: message });
   }
 });
 


### PR DESCRIPTION
## Summary
- update input-app messages for public key fetch and QR generation errors
- display server-provided restore errors to users
- return spec-compliant error text from restore-server

## Testing
- `npm run lint` in input-app *(fails: Unexpected any in server/index.ts)*
- `npm run lint` in restore-app

------
https://chatgpt.com/codex/tasks/task_e_6863d16ecfc08323af51fbb06804780b