### PR TITLE
Support bitflag-based multi-select inputs

### DIFF
--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -40,7 +40,11 @@ const App: React.FC = () => {
         setTemplate(data);
         const init: Record<string, string | string[]> = {};
         data.questions.forEach((q) => {
-          init[q.id] = q.type === 'checkbox' ? [] : '';
+          if (q.type === 'multi_select') {
+            init[q.id] = q.bitflag ? '0' : [];
+          } else {
+            init[q.id] = '';
+          }
         });
         setFormData(init);
       })

--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -56,6 +56,26 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
     }
   };
 
+  const handleMultiSelectChange = (
+    field: Question,
+    e: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    const { value, checked } = e.target;
+    if (field.bitflag) {
+      const bit = 1 << (Number(value) - 1);
+      const current = Number(data[field.id] || 0);
+      const updated = checked ? current | bit : current & ~bit;
+      onChange(field.id, String(updated));
+    } else {
+      const current = Array.isArray(data[field.id]) ? (data[field.id] as string[]) : [];
+      if (checked) {
+        onChange(field.id, [...current, value]);
+      } else {
+        onChange(field.id, current.filter((v) => v !== value));
+      }
+    }
+  };
+
   const renderField = (field: Question) => {
     switch (field.type) {
       case 'text':
@@ -152,18 +172,26 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
         return (
           <div>
             {field.options?.map((opt) => {
-              const checked = Array.isArray(data[field.id])
-                ? (data[field.id] as string[]).includes(String(opt.id))
-                : false;
+              const optVal = String(opt.id);
+              let checked = false;
+              if (field.bitflag) {
+                const mask = Number(data[field.id] || 0);
+                const bit = 1 << (Number(optVal) - 1);
+                checked = (mask & bit) !== 0;
+              } else {
+                checked = Array.isArray(data[field.id])
+                  ? (data[field.id] as string[]).includes(optVal)
+                  : false;
+              }
               return (
                 <div className="form-check form-check-inline" key={opt.id}>
                   <input
                     className="form-check-input"
                     type="checkbox"
                     name={field.id}
-                    value={String(opt.id)}
+                    value={optVal}
                     checked={checked}
-                    onChange={handleChange}
+                    onChange={(e) => handleMultiSelectChange(field, e)}
                   />
                   <label className="form-check-label">{opt.label}</label>
                 </div>


### PR DESCRIPTION
## Summary
- initialize multi-select values correctly when templates load
- encode bitflag multi-select selections as bitmasks
- render multi-select checkboxes with bitflag support

## Testing
- `npm run build` *(fails: Cannot find module 'qrcode' or its corresponding type declarations)*
- `npm run build` in `server` *(fails: Cannot find module 'dotenv' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6863e3e180f0832393acd377c34b52ab