### PR TITLE
Implement conditional navigation for step-based form

### DIFF
--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -7,6 +7,7 @@ import { fetchPublicKey } from './utils/fetchKey';
 import { encodeAndEncrypt } from './logic/encodeAndEncrypt';
 import { generateQrFromEncrypted } from './logic/qrGenerator';
 import { postQrGeneratedLog } from './api/logApi';
+import { isVisible } from './utils/isVisible';
 import ErrorBanner from './components/ErrorBanner';
 
 const App: React.FC = () => {
@@ -18,6 +19,20 @@ const App: React.FC = () => {
   const [step, setStep] = useState(0);
   const [qrGenerated, setQrGenerated] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  const visibleQuestions = template
+    ? template.questions.filter((q) => isVisible(q, formData))
+    : [];
+
+  useEffect(() => {
+    if (!template) return;
+    const currentVisible = template.questions.filter((q) =>
+      isVisible(q, formData)
+    );
+    if (step >= currentVisible.length) {
+      setStep(Math.max(0, currentVisible.length - 1));
+    }
+  }, [formData, template, step]);
 
   useEffect(() => {
     fetchPublicKey()
@@ -132,11 +147,13 @@ const App: React.FC = () => {
             >
               戻る
             </button>
-            {step < template.questions.length - 1 ? (
+            {step < visibleQuestions.length - 1 ? (
               <button
                 type="button"
                 className="btn btn-primary btn-lg"
-                onClick={() => setStep((s) => Math.min(template.questions.length - 1, s + 1))}
+                onClick={() =>
+                  setStep((s) => Math.min(visibleQuestions.length - 1, s + 1))
+                }
               >
                 次へ
               </button>

--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Template, Question } from '../../../shared/templates';
+import { isVisible } from '../utils/isVisible';
 
 interface Props {
   template: Template;
@@ -8,14 +9,6 @@ interface Props {
 }
 
 export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
-  const isVisible = (q: Question) => {
-    if (!q.conditional_on || !q.conditional_value) return true;
-    const target = data[q.conditional_on];
-    if (Array.isArray(target)) {
-      return target.some((v) => q.conditional_value!.includes(v));
-    }
-    return q.conditional_value.includes(target as string | number);
-  };
 
   const hasError = (q: Question) => {
     const val = data[q.id];
@@ -210,7 +203,7 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
   return (
     <div>
       {template.questions.map((q) =>
-        isVisible(q) ? (
+        isVisible(q, data) ? (
           <div className="mb-3" key={q.id}>
             <label className="form-label">{q.label}</label>
             {renderField(q)}

--- a/input-app/src/components/StepForm.tsx
+++ b/input-app/src/components/StepForm.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { Template, Question } from '../../../shared/templates';
+import { isVisible } from '../utils/isVisible';
 
 interface Props {
   template: Template;
@@ -9,7 +10,9 @@ interface Props {
 }
 
 const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
-  const field: Question = template.questions[step];
+  const visibleQuestions = template.questions.filter((q) => isVisible(q, data));
+  const field: Question | undefined = visibleQuestions[step];
+  if (!field) return null;
 
   const hasError = (q: Question) => {
     const val = data[q.id];

--- a/input-app/src/utils/isVisible.ts
+++ b/input-app/src/utils/isVisible.ts
@@ -1,0 +1,10 @@
+import type { Question } from '../../../shared/templates';
+
+export function isVisible(question: Question, answers: Record<string, string | string[]>): boolean {
+  if (!question.conditional_on || !question.conditional_value) return true;
+  const target = answers[question.conditional_on];
+  if (Array.isArray(target)) {
+    return target.some((v) => question.conditional_value!.includes(v));
+  }
+  return question.conditional_value.includes(target as string | number);
+}


### PR DESCRIPTION
## Summary
- add visibility helper to centralize logic
- update StepForm to filter visible questions
- adjust App navigation to skip hidden questions
- reuse helper in FormRenderer

## Testing
- `npm ci`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863e889cd488323b9758b6c4dcdf0de