### PR TITLE
Restore app uses schema for decode

### DIFF
--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -1,17 +1,32 @@
 import React, { useState } from 'react';
 import { decryptQr } from './api';
-import { parseCsv } from './utils/csvParser';
+import { parseCsvValues, mapValuesToLabels } from './utils/csvParser';
+import type { Template } from '../../shared/templates';
 
 const App: React.FC = () => {
   const [input, setInput] = useState('');
   const [result, setResult] = useState<{ label: string; value: string }[]>([]);
   const [error, setError] = useState('');
+  const [warning, setWarning] = useState('');
 
   const handleSubmit = async () => {
     try {
       const csv = await decryptQr(input.trim());
-      const parsed = parseCsv(csv);
-      setResult(parsed);
+      const values = parseCsvValues(csv);
+      const departmentId = values.shift() || '';
+      const res = await fetch(`/templates/${departmentId}.json`);
+      const template: Template = await res.json();
+      const payloadBytes = atob(input.trim()).length;
+      if (
+        template.max_payload_bytes &&
+        payloadBytes > template.max_payload_bytes
+      ) {
+        setWarning('QRデータが規定サイズを超えています');
+      } else {
+        setWarning('');
+      }
+      const labeled = mapValuesToLabels(values, template, true);
+      setResult(labeled);
       setError('');
     } catch (e) {
       console.error(e);
@@ -23,6 +38,7 @@ const App: React.FC = () => {
         );
       }
       setResult([]);
+      setWarning('');
     }
   };
 
@@ -44,6 +60,9 @@ const App: React.FC = () => {
         復元
       </button>
       {error && <div className="alert alert-danger mt-3">{error}</div>}
+      {warning && !error && (
+        <div className="alert alert-warning mt-3">{warning}</div>
+      )}
       {result.length > 0 && (
         <table className="table table-bordered mt-3">
           <tbody>

--- a/restore-app/src/utils/csvParser.ts
+++ b/restore-app/src/utils/csvParser.ts
@@ -1,7 +1,91 @@
-export function parseCsv(csv: string): { label: string; value: string }[] {
-  const lines = csv.trim().split('\n');
-  return lines.map((line, i) => ({
-    label: `質問${i + 1}`,
-    value: line.trim()
-  }));
+import type { Template } from '../../../shared/templates';
+
+function splitCsvLine(line: string): string[] {
+  const result: string[] = [];
+  let current = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (inQuotes) {
+      if (char === '"') {
+        if (line[i + 1] === '"') {
+          current += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        current += char;
+      }
+    } else {
+      if (char === '"') {
+        inQuotes = true;
+      } else if (char === ',') {
+        result.push(current);
+        current = '';
+      } else if (char !== '\r' && char !== '\n') {
+        current += char;
+      }
+    }
+  }
+  result.push(current);
+  return result;
+}
+
+export function parseCsvValues(csv: string): string[] {
+  return splitCsvLine(csv.trim());
+}
+
+export function mapValuesToLabels(
+  values: string[],
+  template: Template,
+  filterConditional = false
+): { label: string; value: string }[] {
+  const answers: Record<string, string | string[]> = {};
+  const result: { label: string; value: string }[] = [];
+
+  template.questions.forEach((q, idx) => {
+    const raw = values[idx] ?? '';
+    let display = raw;
+    let store: string | string[] = raw;
+
+    if (q.type === 'multi_select') {
+      if (q.bitflag) {
+        const mask = Number(raw);
+        const opts =
+          q.options?.filter(opt => (mask & Number(opt.id)) !== 0).map(o => o.label) ?? [];
+        display = opts.join(';');
+        store = opts;
+      } else {
+        const ids = raw.split(';').filter(Boolean);
+        const opts = ids.map(id => q.options?.find(o => String(o.id) === id)?.label ?? id);
+        display = opts.join(';');
+        store = opts;
+      }
+    } else if (q.type === 'select') {
+      const opt = q.options?.find(o => String(o.id) === raw);
+      if (opt) display = opt.label;
+      store = display;
+    }
+
+    answers[q.id] = store;
+
+    if (filterConditional && q.conditional_on && q.conditional_value) {
+      const target = answers[q.conditional_on];
+      let visible = false;
+      if (Array.isArray(target)) {
+        visible = target.some(v =>
+          q.conditional_value!.some(c => String(c) === String(v))
+        );
+      } else {
+        visible = q.conditional_value.some(c => String(c) === String(target));
+      }
+      if (!visible) return;
+    }
+
+    result.push({ label: q.label, value: display });
+  });
+
+  return result;
 }

--- a/restore-app/src/utils/isVisible.ts
+++ b/restore-app/src/utils/isVisible.ts
@@ -1,0 +1,12 @@
+import type { Question } from '../../../shared/templates';
+
+export function isVisible(question: Question, answers: Record<string, string | string[]>): boolean {
+  if (!question.conditional_on || !question.conditional_value) return true;
+  const target = answers[question.conditional_on];
+  if (Array.isArray(target)) {
+    return target.some(v =>
+      question.conditional_value!.some(c => String(c) === String(v))
+    );
+  }
+  return question.conditional_value.some(c => String(c) === String(target));
+}


### PR DESCRIPTION
## Summary
- improve CSV parsing and add label mapping according to templates
- warn when QR payload size exceeds template limit
- show only questions that met conditional logic

## Testing
- `npm run lint` in restore-app
- `npm run build` in restore-app
- `npm run build` in restore-server

------
https://chatgpt.com/codex/tasks/task_e_6863fb964ec48323a7f5eb7dd824ba72