### PR TITLE
Improve Docker startup reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,23 @@ services:
       dockerfile: Dockerfile
     env_file:
       - ./restore-app/.env
+    depends_on:
+      - restore-server
+    environment:
+      WAIT_FOR_HOST: "restore-server:3000"
     ports:
       - "5174:80"
+    networks:
+      - qr_monsin_network
+
+  restore-server:
+    build:
+      context: ./restore-server
+      dockerfile: Dockerfile
+    env_file:
+      - ./restore-server/.env
+    ports:
+      - "3000:3000"
     networks:
       - qr_monsin_network
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+set -e
+
+echo "Working directory: $(pwd)"
+echo "Node version: $(node -v)"
+echo "NPM version: $(npm -v)"
+echo "NODE_ENV: ${NODE_ENV:-development}"
+
+if [ -n "$WAIT_FOR_HOST" ]; then
+  HOST=$(echo "$WAIT_FOR_HOST" | cut -d: -f1)
+  PORT=$(echo "$WAIT_FOR_HOST" | cut -d: -f2)
+  echo "Waiting for $HOST:$PORT"
+  while ! nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+fi
+
+exec "$@"

--- a/input-app/.dockerignore
+++ b/input-app/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+server/node_modules
+server/dist

--- a/input-app/Dockerfile
+++ b/input-app/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Install frontend dependencies and build
 COPY package*.json ./
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 COPY . .
 RUN npm run build
 
@@ -13,6 +14,7 @@ RUN npm run build
 WORKDIR /app/server
 COPY server/package*.json ./
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 COPY server .
 RUN npm run build
 
@@ -39,5 +41,11 @@ RUN npm install --omit=dev
 ENV PORT=80
 EXPOSE 80
 
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1
+
 WORKDIR /app
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server/dist/index.js"]

--- a/input-app/docker-entrypoint.sh
+++ b/input-app/docker-entrypoint.sh
@@ -1,0 +1,1 @@
+../docker-entrypoint.sh

--- a/restore-app/.dockerignore
+++ b/restore-app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/restore-app/Dockerfile
+++ b/restore-app/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 
 COPY . .
 
@@ -17,7 +18,12 @@ FROM nginx:1.21-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost/ || exit 1
 
 EXPOSE 80
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/restore-app/docker-entrypoint.sh
+++ b/restore-app/docker-entrypoint.sh
@@ -1,0 +1,1 @@
+../docker-entrypoint.sh

--- a/restore-server/.dockerignore
+++ b/restore-server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/restore-server/Dockerfile
+++ b/restore-server/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: build
+FROM node:18-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
+COPY . .
+RUN npm run build
+
+# Stage 2: runtime
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+COPY --from=build /app/keys ./keys
+RUN npm install --omit=dev
+
+ENV PORT=3000
+EXPOSE 3000
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["node", "dist/server.js"]

--- a/restore-server/docker-entrypoint.sh
+++ b/restore-server/docker-entrypoint.sh
@@ -1,0 +1,1 @@
+../docker-entrypoint.sh


### PR DESCRIPTION
## Summary
- add shared docker-entrypoint for runtime logging and waits
- check TypeScript types during Docker builds
- add healthchecks to Dockerfiles
- add Dockerfile for restore-server and update compose
- ignore node_modules and dist in Docker contexts

## Testing
- `npm install` and `npm run build` in input-app
- `npm install` and `npm run build` in restore-app
- `npm install` and `npm run build` in restore-server

------
https://chatgpt.com/codex/tasks/task_e_6863fd1ea6d88323be214a6423bdf4ed