### PR TITLE
Improve Docker startup reliability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ version: '3.8'
 services:
   input-app:
     build:
-      context: ./input-app
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./input-app/Dockerfile
     ports:
       - "5173:80"
     networks:
@@ -12,8 +12,8 @@ services:
 
   restore-app:
     build:
-      context: ./restore-app
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./restore-app/Dockerfile
     env_file:
       - ./restore-app/.env
     depends_on:
@@ -27,8 +27,8 @@ services:
 
   restore-server:
     build:
-      context: ./restore-server
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./restore-server/Dockerfile
     env_file:
       - ./restore-server/.env
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,23 @@ services:
       dockerfile: Dockerfile
     env_file:
       - ./restore-app/.env
+    depends_on:
+      - restore-server
+    environment:
+      WAIT_FOR_HOST: "restore-server:3000"
     ports:
       - "5174:80"
+    networks:
+      - qr_monsin_network
+
+  restore-server:
+    build:
+      context: ./restore-server
+      dockerfile: Dockerfile
+    env_file:
+      - ./restore-server/.env
+    ports:
+      - "3000:3000"
     networks:
       - qr_monsin_network
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Starting $(basename "$0")"
+
+echo "Working directory: $(pwd)"
+echo "Node version: $(node -v)"
+echo "NPM version: $(npm -v)"
+echo "NODE_ENV: ${NODE_ENV:-development}"
+
+if [ -n "$WAIT_FOR_HOST" ]; then
+  HOST=$(echo "$WAIT_FOR_HOST" | cut -d: -f1)
+  PORT=$(echo "$WAIT_FOR_HOST" | cut -d: -f2)
+  echo "Waiting for $HOST:$PORT"
+  while ! nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+fi
+
+exec "$@"

--- a/input-app/.dockerignore
+++ b/input-app/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+server/node_modules
+server/dist

--- a/input-app/Dockerfile
+++ b/input-app/Dockerfile
@@ -4,18 +4,21 @@ FROM node:18-alpine AS build
 WORKDIR /app
 
 # Install frontend dependencies and build
-COPY package*.json ./
+COPY input-app/package*.json ./
+COPY shared ./shared
+COPY input-app/tsconfig.app.json ./
+COPY input-app/src ./src
 RUN npm install
-RUN node -v && npm -v && npx tsc --noEmit
-COPY . .
+RUN node -v && npm -v && npx tsc --project tsconfig.app.json --noEmit
+COPY input-app/. .
 RUN npm run build
 
 # Build the Express server
 WORKDIR /app/server
-COPY server/package*.json ./
+COPY input-app/server/package*.json ./
 RUN npm install
 RUN node -v && npm -v && npx tsc --noEmit
-COPY server .
+COPY input-app/server ./
 RUN npm run build
 
 # Stage 2: Run with Node
@@ -41,7 +44,7 @@ RUN npm install --omit=dev
 ENV PORT=80
 EXPOSE 80
 
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY input-app/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1

--- a/input-app/Dockerfile
+++ b/input-app/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 # Install frontend dependencies and build
 COPY package*.json ./
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 COPY . .
 RUN npm run build
 
@@ -13,6 +14,7 @@ RUN npm run build
 WORKDIR /app/server
 COPY server/package*.json ./
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 COPY server .
 RUN npm run build
 
@@ -39,5 +41,11 @@ RUN npm install --omit=dev
 ENV PORT=80
 EXPOSE 80
 
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1
+
 WORKDIR /app
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["node", "server/dist/index.js"]

--- a/input-app/docker-entrypoint.sh
+++ b/input-app/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Starting $(basename "$0")"
+
+echo "Working directory: $(pwd)"
+echo "Node version: $(node -v)"
+echo "NPM version: $(npm -v)"
+echo "NODE_ENV: ${NODE_ENV:-development}"
+
+if [ -n "$WAIT_FOR_HOST" ]; then
+  HOST=$(echo "$WAIT_FOR_HOST" | cut -d: -f1)
+  PORT=$(echo "$WAIT_FOR_HOST" | cut -d: -f2)
+  echo "Waiting for $HOST:$PORT"
+  while ! nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+fi
+
+exec "$@"

--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { departmentMap } from '../../shared/templates';
-import type { Template } from '../../shared/templates';
+import { departmentMap } from '@shared/templates';
+import type { Template } from '@shared/templates';
 import StepForm from './components/StepForm';
 import { buildCsv } from './utils/csvBuilder';
 import { fetchPublicKey } from './utils/fetchKey';
@@ -20,7 +20,7 @@ const App: React.FC = () => {
   const [qrGenerated, setQrGenerated] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const visibleQuestions = template
+  const visibleQuestions = template && template.questions
     ? template.questions.filter((q) => isVisible(q, formData))
     : [];
 

--- a/input-app/src/api/logApi.ts
+++ b/input-app/src/api/logApi.ts
@@ -1,6 +1,6 @@
 export async function postQrGeneratedLog(formVersion: string): Promise<void> {
   try {
-    await fetch('/api/logs/qr-generated', {
+    const response = await fetch('/api/logs/qr-generated', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
@@ -8,7 +8,10 @@ export async function postQrGeneratedLog(formVersion: string): Promise<void> {
         timestamp: new Date().toISOString(),
       }),
     });
+    if (!response.ok) {
+      console.warn(`ログ送信に失敗しました (HTTP Status: ${response.status}, ${response.statusText})。処理は継続します。`);
+    }
   } catch (err) {
-    console.warn('ログ送信に失敗しましたが処理は継続します', err);
+    console.warn('ログ送信に失敗しました (ネットワークエラー)。処理は継続します。', err);
   }
 }

--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Template, Question } from '../../../shared/templates';
+import type { Template, Question } from '@shared/templates';
 import { isVisible } from '../utils/isVisible';
 
 interface Props {

--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -116,7 +116,7 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
             onChange={handleChange}
           >
             <option value="">選択してください</option>
-            {field.options?.map((opt) => (
+            {Array.isArray(field.options) && field.options.map((opt) => (
               <option key={opt.id} value={String(opt.id)}>
                 {opt.label}
               </option>
@@ -126,7 +126,7 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
       case 'multi_select':
         return (
           <div>
-            {field.options?.map((opt) => {
+            {Array.isArray(field.options) && field.options.map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (field.bitflag) {

--- a/input-app/src/components/StepForm.tsx
+++ b/input-app/src/components/StepForm.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { Template, Question } from '../../../shared/templates';
+import type { Template, Question } from '@shared/templates';
 import { isVisible } from '../utils/isVisible';
 
 interface Props {

--- a/input-app/src/components/StepForm.tsx
+++ b/input-app/src/components/StepForm.tsx
@@ -125,7 +125,7 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
             onChange={handleChange}
           >
             <option value="">選択してください</option>
-            {q.options?.map((opt) => (
+            {Array.isArray(q.options) && q.options.map((opt) => (
               <option key={opt.id} value={String(opt.id)}>
                 {opt.label}
               </option>
@@ -135,7 +135,7 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
       case 'multi_select':
         return (
           <div>
-            {q.options?.map((opt) => {
+            {Array.isArray(q.options) && q.options.map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (q.bitflag) {

--- a/input-app/src/utils/csvBuilder.ts
+++ b/input-app/src/utils/csvBuilder.ts
@@ -1,4 +1,4 @@
-import type { Template, Question } from '../../../shared/templates';
+import type { Template, Question } from '@shared/templates';
 
 function escapeCsv(value: string): string {
   if (/[,\n"]/.test(value)) {

--- a/input-app/src/utils/isVisible.ts
+++ b/input-app/src/utils/isVisible.ts
@@ -1,4 +1,4 @@
-import type { Question } from '../../../shared/templates';
+import type { Question } from '@shared/templates';
 
 export function isVisible(question: Question, answers: Record<string, string | string[]>): boolean {
   if (!question.conditional_on || !question.conditional_value) return true;

--- a/input-app/tsconfig.app.json
+++ b/input-app/tsconfig.app.json
@@ -17,6 +17,12 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
 
+    /* Path mapping */
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["shared/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -26,5 +32,5 @@
     "noUncheckedSideEffectImports": true
   },
   "types": ["node"],
-  "include": ["src", "src/custom.d.ts", "../shared"],
+  "include": ["src", "src/custom.d.ts", "shared"],
 }

--- a/input-app/vite.config.ts
+++ b/input-app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       buffer: 'buffer',
+      '@shared': path.resolve(__dirname, '../shared'),
     },
   },
   define: {

--- a/restore-app/.dockerignore
+++ b/restore-app/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/restore-app/Dockerfile
+++ b/restore-app/Dockerfile
@@ -3,22 +3,27 @@ FROM node:18-alpine AS build
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY restore-app/package*.json ./
+COPY shared ./shared
+COPY restore-app/tsconfig.app.json ./
+COPY restore-app/src ./src
 
 RUN npm install
-RUN node -v && npm -v && npx tsc --noEmit
+RUN node -v && npm -v && npx tsc --project tsconfig.app.json --noEmit
 
-COPY . .
+COPY restore-app/. .
 
 RUN npm run build
 
 # Stage 2: Serve the application with Nginx
 FROM nginx:1.21-alpine
 
+RUN apk add --no-cache netcat-openbsd
+
 COPY --from=build /app/dist /usr/share/nginx/html
 
-COPY nginx.conf /etc/nginx/conf.d/default.conf
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY restore-app/nginx.conf /etc/nginx/conf.d/default.conf
+COPY restore-app/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost/ || exit 1

--- a/restore-app/Dockerfile
+++ b/restore-app/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY package*.json ./
 
 RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
 
 COPY . .
 
@@ -17,7 +18,12 @@ FROM nginx:1.21-alpine
 COPY --from=build /app/dist /usr/share/nginx/html
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost/ || exit 1
 
 EXPOSE 80
 
+ENTRYPOINT ["docker-entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/restore-app/docker-entrypoint.sh
+++ b/restore-app/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Starting $(basename "$0")"
+
+echo "Working directory: $(pwd)"
+echo "Node version: $(node -v)"
+echo "NPM version: $(npm -v)"
+echo "NODE_ENV: ${NODE_ENV:-development}"
+
+if [ -n "$WAIT_FOR_HOST" ]; then
+  HOST=$(echo "$WAIT_FOR_HOST" | cut -d: -f1)
+  PORT=$(echo "$WAIT_FOR_HOST" | cut -d: -f2)
+  echo "Waiting for $HOST:$PORT"
+  while ! nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+fi
+
+exec "$@"

--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { decryptQr } from './api';
 import { parseCsvValues, mapValuesToLabels } from './utils/csvParser';
-import type { Template } from '../../shared/templates';
+import type { Template } from '@shared/templates';
 
 const App: React.FC = () => {
   const [input, setInput] = useState('');

--- a/restore-app/src/utils/csvParser.ts
+++ b/restore-app/src/utils/csvParser.ts
@@ -1,4 +1,4 @@
-import type { Template } from '../../../shared/templates';
+import type { Template } from '@shared/templates';
 
 function splitCsvLine(line: string): string[] {
   const result: string[] = [];

--- a/restore-app/src/utils/isVisible.ts
+++ b/restore-app/src/utils/isVisible.ts
@@ -1,4 +1,4 @@
-import type { Question } from '../../../shared/templates';
+import type { Question } from '@shared/templates';
 
 export function isVisible(question: Question, answers: Record<string, string | string[]>): boolean {
   if (!question.conditional_on || !question.conditional_value) return true;

--- a/restore-app/tsconfig.app.json
+++ b/restore-app/tsconfig.app.json
@@ -17,6 +17,12 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
 
+    /* Path mapping */
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["shared/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,
@@ -26,5 +32,5 @@
     "noUncheckedSideEffectImports": true
   },
   "types": ["node"],
-  "include": ["src", "src/custom.d.ts", "../shared"],
+  "include": ["src", "src/custom.d.ts", "shared"],
 }

--- a/restore-app/vite.config.ts
+++ b/restore-app/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -7,6 +8,7 @@ export default defineConfig({
   resolve: {
     alias: {
       buffer: 'buffer',
+      '@shared': path.resolve(__dirname, '../shared'),
     },
   },
   define: {

--- a/restore-server/.dockerignore
+++ b/restore-server/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/restore-server/Dockerfile
+++ b/restore-server/Dockerfile
@@ -1,0 +1,28 @@
+# Stage 1: build
+FROM node:18-alpine AS build
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+RUN node -v && npm -v && npx tsc --noEmit
+COPY . .
+RUN npm run build
+
+# Stage 2: runtime
+FROM node:18-alpine
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/package.json ./package.json
+COPY --from=build /app/package-lock.json ./package-lock.json
+COPY --from=build /app/keys ./keys
+RUN npm install --omit=dev
+
+ENV PORT=3000
+EXPOSE 3000
+
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["node", "dist/server.js"]

--- a/restore-server/Dockerfile
+++ b/restore-server/Dockerfile
@@ -2,10 +2,13 @@
 FROM node:18-alpine AS build
 WORKDIR /app
 
-COPY package*.json ./
+COPY restore-server/package*.json ./
+COPY shared ./shared
+COPY restore-server/tsconfig.json ./
+COPY restore-server/src ./src
 RUN npm install
-RUN node -v && npm -v && npx tsc --noEmit
-COPY . .
+RUN node -v && npm -v && npx tsc --project tsconfig.json --noEmit || (echo "❌ TypeScript check failed"; exit 1)
+COPY restore-server/. .
 RUN npm run build
 
 # Stage 2: runtime
@@ -20,7 +23,7 @@ RUN npm install --omit=dev
 ENV PORT=3000
 EXPOSE 3000
 
-COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY restore-server/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s CMD wget -qO- http://localhost:$PORT/ || exit 1
 

--- a/restore-server/docker-entrypoint.sh
+++ b/restore-server/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+
+echo "Starting $(basename "$0")"
+
+echo "Working directory: $(pwd)"
+echo "Node version: $(node -v)"
+echo "NPM version: $(npm -v)"
+echo "NODE_ENV: ${NODE_ENV:-development}"
+
+if [ -n "$WAIT_FOR_HOST" ]; then
+  HOST=$(echo "$WAIT_FOR_HOST" | cut -d: -f1)
+  PORT=$(echo "$WAIT_FOR_HOST" | cut -d: -f2)
+  echo "Waiting for $HOST:$PORT"
+  while ! nc -z "$HOST" "$PORT"; do
+    sleep 1
+  done
+fi
+
+exec "$@"

--- a/restore-server/src/decrypt.ts
+++ b/restore-server/src/decrypt.ts
@@ -1,5 +1,10 @@
 import { KeyObject, privateDecrypt, constants } from 'crypto';
 
+/**
+ * 現在は単一の秘密鍵のみを使用して復号しているが、
+ * このロジックは将来的な鍵ローテーション（例：年次更新）への対応を見越して設計されている。
+ * 例えば、6月1日〜7月1日の移行期間中に新旧2つの鍵で復号を試行するなどの運用を想定している。
+ */
 export function decryptWithKeys(encrypted: Buffer, keys: KeyObject[]): Buffer {
   let lastError: unknown;
   for (const key of keys) {


### PR DESCRIPTION
## Summary
- add shared docker-entrypoint for runtime logging and waits
- check TypeScript types during Docker builds
- add healthchecks to Dockerfiles
- add Dockerfile for restore-server and update compose
- ignore node_modules and dist in Docker contexts
- replace entrypoint symlinks with files
- add startup banner in entrypoint scripts

## Testing
- `npm run build` in input-app
- `npm run build` in restore-app
- `npm run build` in restore-server

------
https://chatgpt.com/codex/tasks/task_e_6863fd1ea6d88323be214a6423bdf4ed