### PR TITLE
Fix Docker build by copying TS sources before type check

### DIFF
--- a/input-app/Dockerfile
+++ b/input-app/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 # Install frontend dependencies and build
 COPY package*.json tsconfig*.json ./
 RUN npm install
+# Copy sources for type checking
+COPY src ./src
 RUN node -v && npm -v && if [ -f tsconfig.json ]; then npx tsc --noEmit || echo "Type-check failed, continuing"; else echo "Skipping type-check (no tsconfig.json)"; fi
 COPY . .
 RUN npm run build
@@ -14,6 +16,8 @@ RUN npm run build
 WORKDIR /app/server
 COPY server/package*.json server/tsconfig*.json ./
 RUN npm install
+# Copy server sources for type checking
+COPY server/*.ts ./
 RUN node -v && npm -v && if [ -f tsconfig.json ]; then npx tsc --noEmit || echo "Type-check failed, continuing"; else echo "Skipping type-check (no tsconfig.json)"; fi
 COPY server .
 RUN npm run build


### PR DESCRIPTION
## Summary
- copy `src` and server TypeScript files before running `npx tsc --noEmit`

## Testing
- `npm install --omit=dev`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686404cf24bc8323b622ece4a6bcfd59