### PR TITLE
Fix shared types in input-app Docker build

### DIFF
--- a/input-app/Dockerfile
+++ b/input-app/Dockerfile
@@ -23,6 +23,7 @@ RUN npx tsc --project tsconfig.json --showConfig || (echo "\u274C Invalid tsconf
 RUN npx tsc --project tsconfig.json --listFiles --noEmit || (echo "\u26A0\uFE0F No files found for compilation"; exit 1)
 
 # Run TypeScript check without emitting files
+COPY ../shared ./shared
 RUN npx tsc --project tsconfig.json --noEmit || (echo "\u274C TypeScript check failed"; exit 1)
 COPY . .
 RUN npm run build


### PR DESCRIPTION
## Summary
- ensure shared types directory is copied before TypeScript compilation in `input-app` Dockerfile

## Testing
- `npm --prefix input-app install --ignore-scripts`
- `npm --prefix input-app run lint`
- `npm --prefix input-app run build`
- `npm --prefix input-app/server install --ignore-scripts`
- `npm --prefix input-app/server run build`


------
https://chatgpt.com/codex/tasks/task_e_68640cfc50f08323ad4bef1c594b04c6