### PR TITLE
Fix undefined options crash

### DIFF
--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -106,7 +106,8 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
             onChange={handleChange}
           />
         );
-      case 'select':
+      case 'select': {
+        const options = Array.isArray(field.options) ? field.options : [];
         return (
           <select
             className={`form-select${hasError(field) ? ' is-invalid' : ''}`}
@@ -116,17 +117,18 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
             onChange={handleChange}
           >
             <option value="">選択してください</option>
-            {field.options?.map((opt) => (
+            {options.map((opt) => (
               <option key={opt.id} value={String(opt.id)}>
                 {opt.label}
               </option>
             ))}
           </select>
         );
+      }
       case 'multi_select':
         return (
           <div>
-            {field.options?.map((opt) => {
+            {(Array.isArray(field.options) ? field.options : []).map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (field.bitflag) {

--- a/input-app/src/components/StepForm.tsx
+++ b/input-app/src/components/StepForm.tsx
@@ -115,7 +115,8 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
             onChange={handleChange}
           />
         );
-      case 'select':
+      case 'select': {
+        const options = Array.isArray(q.options) ? q.options : [];
         return (
           <select
             className={`form-select${hasError(q) ? ' is-invalid' : ''}`}
@@ -125,17 +126,18 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
             onChange={handleChange}
           >
             <option value="">選択してください</option>
-            {q.options?.map((opt) => (
+            {options.map((opt) => (
               <option key={opt.id} value={String(opt.id)}>
                 {opt.label}
               </option>
             ))}
           </select>
         );
+      }
       case 'multi_select':
         return (
           <div>
-            {q.options?.map((opt) => {
+            {(Array.isArray(q.options) ? q.options : []).map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (q.bitflag) {


### PR DESCRIPTION
## Summary
- guard against undefined `options` in StepForm and FormRenderer
- add safety when iterating over `question.options`

## Testing
- `npm ci` in root, input-app, restore-app
- `npm run lint` in input-app and restore-app

------
https://chatgpt.com/codex/tasks/task_e_6864252c72908323b7df3826034816db