### PR TITLE
Fix options guard in questionnaire

### DIFF
--- a/input-app/src/App.tsx
+++ b/input-app/src/App.tsx
@@ -10,6 +10,17 @@ import { postQrGeneratedLog } from './api/logApi';
 import { isVisible } from './utils/isVisible';
 import ErrorBanner from './components/ErrorBanner';
 
+const validateTemplate = (tpl: Template) => {
+  tpl.questions.forEach((q) => {
+    if (
+      (q.type === 'select' || q.type === 'multi_select') &&
+      !Array.isArray(q.options)
+    ) {
+      console.warn(`❗ テンプレートの質問 ${q.id} は options が未定義です`);
+    }
+  });
+};
+
 const App: React.FC = () => {
   const [publicKey, setPublicKey] = useState<string | null>(null);
   const [error, setError] = useState('');
@@ -54,6 +65,7 @@ const App: React.FC = () => {
     fetch(`/templates/${departmentId}.json`)
       .then((res) => res.json())
       .then((data: Template) => {
+        validateTemplate(data);
         setTemplate(data);
         const init: Record<string, string | string[]> = {};
         data.questions.forEach((q) => {

--- a/input-app/src/components/FormRenderer.tsx
+++ b/input-app/src/components/FormRenderer.tsx
@@ -125,10 +125,11 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
           </select>
         );
       }
-      case 'multi_select':
+      case 'multi_select': {
+        const options = Array.isArray(field.options) ? field.options : [];
         return (
           <div>
-            {(Array.isArray(field.options) ? field.options : []).map((opt) => {
+            {options.map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (field.bitflag) {
@@ -159,6 +160,7 @@ export const FormRenderer: React.FC<Props> = ({ template, data, onChange }) => {
             )}
           </div>
         );
+      }
       default:
         return null;
     }

--- a/input-app/src/components/StepForm.tsx
+++ b/input-app/src/components/StepForm.tsx
@@ -134,10 +134,11 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
           </select>
         );
       }
-      case 'multi_select':
+      case 'multi_select': {
+        const options = Array.isArray(q.options) ? q.options : [];
         return (
           <div>
-            {(Array.isArray(q.options) ? q.options : []).map((opt) => {
+            {options.map((opt) => {
               const optVal = String(opt.id);
               let checked = false;
               if (q.bitflag) {
@@ -168,6 +169,7 @@ const StepForm: React.FC<Props> = ({ template, step, data, onChange }) => {
             )}
           </div>
         );
+      }
       default:
         return null;
     }

--- a/restore-app/src/App.tsx
+++ b/restore-app/src/App.tsx
@@ -3,6 +3,17 @@ import { decryptQr } from './api';
 import { parseCsvValues, mapValuesToLabels } from './utils/csvParser';
 import type { Template } from '../../shared/templates';
 
+const validateTemplate = (tpl: Template) => {
+  tpl.questions.forEach(q => {
+    if (
+      (q.type === 'select' || q.type === 'multi_select') &&
+      !Array.isArray(q.options)
+    ) {
+      console.warn(`❗ テンプレートの質問 ${q.id} は options が未定義です`);
+    }
+  });
+};
+
 const App: React.FC = () => {
   const [input, setInput] = useState('');
   const [result, setResult] = useState<{ label: string; value: string }[]>([]);
@@ -16,6 +27,7 @@ const App: React.FC = () => {
       const departmentId = values.shift() || '';
       const res = await fetch(`/templates/${departmentId}.json`);
       const template: Template = await res.json();
+      validateTemplate(template);
       const payloadBytes = atob(input.trim()).length;
       if (
         template.max_payload_bytes &&

--- a/restore-app/src/utils/csvParser.ts
+++ b/restore-app/src/utils/csvParser.ts
@@ -51,27 +51,25 @@ export function mapValuesToLabels(
     let store: string | string[] = raw;
 
     if (q.type === 'multi_select') {
+      const options = Array.isArray(q.options) ? q.options : [];
       if (q.bitflag) {
         const mask = Number(raw);
-        const opts = Array.isArray(q.options)
-          ? q.options
-              .filter(opt => (mask & Number(opt.id)) !== 0)
-              .map(o => o.label)
-          : [];
+        const opts = options
+          .filter(opt => (mask & Number(opt.id)) !== 0)
+          .map(o => o.label);
         display = opts.join(';');
         store = opts;
       } else {
         const ids = raw.split(';').filter(Boolean);
-        const opts = Array.isArray(q.options)
-          ? ids.map(id => q.options?.find(o => String(o.id) === id)?.label ?? id)
-          : ids;
+        const opts = ids.map(
+          id => options.find(o => String(o.id) === id)?.label ?? id
+        );
         display = opts.join(';');
         store = opts;
       }
     } else if (q.type === 'select') {
-      const opt = Array.isArray(q.options)
-        ? q.options.find(o => String(o.id) === raw)
-        : undefined;
+      const options = Array.isArray(q.options) ? q.options : [];
+      const opt = options.find(o => String(o.id) === raw);
       if (opt) display = opt.label;
       store = display;
     }


### PR DESCRIPTION
## Summary
- add template validation when loading templates
- guard select and multi-select rendering when options are missing
- make csv parsing robust to missing options

## Testing
- `npm run lint` in `input-app`
- `npm run lint` in `restore-app`

------
https://chatgpt.com/codex/tasks/task_e_68642709e7248323a1e519f02f53c2ea